### PR TITLE
fix: expiry calculation if cache-control returns no explicit expire-by value

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -222,6 +222,11 @@ func (m *cache) cacheable(r *http.Request, w http.ResponseWriter, status int) (t
 		return 0, false
 	}
 
+	if expireBy.IsZero() {
+		// No explicit expiration - apply default max expiry
+		return time.Duration(m.cfg.MaxExpiry) * time.Second, true
+	}
+
 	expiry := time.Until(expireBy)
 	maxExpiry := time.Duration(m.cfg.MaxExpiry) * time.Second
 

--- a/cache_test.go
+++ b/cache_test.go
@@ -291,6 +291,38 @@ func TestCache_DownstreamFailureDuringStream(t *testing.T) {
 	verifyNoTempFiles(t, dir)
 }
 
+func TestCache_NoCacheControl(t *testing.T) {
+	dir := createTempDir(t)
+
+	next := func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	}
+
+	cfg := &Config{Path: dir, MaxExpiry: 10, Cleanup: 20, AddStatusHeader: true, MaxHeaderPairs: 2, MaxHeaderKeyLen: 30, MaxHeaderValueLen: 100}
+
+	c, err := New(context.Background(), http.HandlerFunc(next), cfg, "cacheify")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "http://localhost/some/path", nil)
+	rw := httptest.NewRecorder()
+
+	c.ServeHTTP(rw, req)
+
+	if state := rw.Header().Get("Cache-Status"); state != cacheMissStatus {
+		t.Errorf("unexpected cache state: want \"miss\", got: %q", state)
+	}
+
+	rw = httptest.NewRecorder()
+
+	c.ServeHTTP(rw, req)
+
+	if state := rw.Header().Get("Cache-Status"); state != cacheHitStatus {
+		t.Errorf("unexpected cache state: want \"hit\", got: %q", state)
+	}
+}
+
 // failingResponseWriter simulates a downstream client that fails after writing N bytes
 type failingResponseWriter struct {
 	http.ResponseWriter


### PR DESCRIPTION
This is a fix for the expiry-time calculation. 

## Problem description:
If the `expireBy` value returned from `cachecontrol.CachableResponseWriter` is zero (*0001-01-01 00:00:00 +0000 UTC*), then the resulting `expiry` duration would be negative. 
As the followup check `if maxExpiry < expiry` also does not clamp the expiry value, the `cacheable` function returns a potential negative duration. 
When this negative value is then stored as **u**int64 in `SetStream`, it gets converted to a very large number (bigger than MaxInt64) - which then leads to incorrect time checks in the `GetStream` function which finally leads to all requests being a cache miss.

```go

func SetStream() {
   ....
        // Write expiry timestamp (8 bytes)
	timestamp := uint64(time.Now().Add(expiry).Unix())  // <------- if expiry is a large negative number, this is problematic
	var expiryBuf [8]byte
	binary.LittleEndian.PutUint64(expiryBuf[:], timestamp)
	if _, err = bufWriter.Write(expiryBuf[:]); err != nil {
		_ = file.Close()
		_ = os.Remove(tempPath) // Clean up temp file
		bufWriter.Reset(nil)
		bufferPool.Put(bufWriter)
		mu.Unlock(c.lm)
		return nil, fmt.Errorf("error writing expiry: %w", err)
	}
   ....
}

```

